### PR TITLE
#16 feat: 상세페이지

### DIFF
--- a/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
+++ b/src/main/java/com/example/calenduck/domain/performance/controller/PerformanceController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,10 @@ public class PerformanceController {
         return ResponseMessage.SuccessResponse("전체 조회 성공", performanceService.getAllPerformances());
     }
 
-
+    @Operation(summary = "상세 조회", description = "전체 조회")
+    @GetMapping("{/performance-id}")
+    public ResponseEntity<?> getDetailPerformance(@PathVariable Long performanceId) {
+        return ResponseMessage.SuccessResponse("상세 조회 성공", performanceService.getDetailPerformance(performanceId));
+    }
 
 }

--- a/src/main/java/com/example/calenduck/domain/performance/dto/response/BasePerformancesResponseDto.java
+++ b/src/main/java/com/example/calenduck/domain/performance/dto/response/BasePerformancesResponseDto.java
@@ -1,8 +1,19 @@
 package com.example.calenduck.domain.performance.dto.response;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class BasePerformancesResponseDto {
 
     private String poster; // 포스터
     private String prfnm; // 공연명
     private String prfcast; // 공연출연진
+
+    public BasePerformancesResponseDto(String poster, String prfnm, String prfcast) {
+        this.poster = poster;
+        this.prfnm = prfnm;
+        this.prfcast = prfcast;
+    }
 }

--- a/src/main/java/com/example/calenduck/domain/performance/dto/response/DetailPerformanceResponseDto.java
+++ b/src/main/java/com/example/calenduck/domain/performance/dto/response/DetailPerformanceResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.calenduck.domain.performance.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DetailPerformanceResponseDto {
+
+    private String poster; // 포스터
+    private String prfnm; // 공연명
+    private String genrenm; // 공연 장르명
+    private String fcltynm; // 공연시설명
+    private String dtguidance; // 공연시간
+    private String stdate; // 공연시작일자
+    private String eddate; // 공연종료일자
+
+    public DetailPerformanceResponseDto(String poster, String prfnm, String genrenm, String fcltynm, String dtguidance, String stdate, String eddate) {
+        this.poster = poster;
+        this.prfnm = prfnm;
+        this.genrenm = genrenm;
+        this.fcltynm = fcltynm;
+        this.dtguidance = dtguidance;
+        this.stdate = stdate;
+        this.eddate = eddate;
+    }
+}

--- a/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/PerformanceService.java
@@ -1,6 +1,7 @@
 package com.example.calenduck.domain.performance.service;
 
 import com.example.calenduck.domain.performance.dto.response.BasePerformancesResponseDto;
+import com.example.calenduck.domain.performance.dto.response.DetailPerformanceResponseDto;
 import com.example.calenduck.domain.performance.repository.PerformanceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +14,6 @@ import java.util.*;
 public class PerformanceService {
 
     private final PerformanceRepository performanceRepository;
-    private final XmlToJson xmlToJson;
 
     // 전체 조회 & 메인
     // 포스터, 공연명, 출연진
@@ -26,8 +26,12 @@ public class PerformanceService {
 //            maps.get("poster");
 //            responseDto.
 //        }
-
         return responseDtos;
+    }
+
+    public DetailPerformanceResponseDto getDetailPerformance(Long performanceId) {
+
+        return null;
     }
 
 }

--- a/src/main/java/com/example/calenduck/domain/performance/service/XmlToMap.java
+++ b/src/main/java/com/example/calenduck/domain/performance/service/XmlToMap.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-public class XmlToJson {
+public class XmlToMap {
     // 1. mt20 id + kopis 인증키로 공연 상세정보 xml로 불러오기 -> 파싱으로 json 등으로 변환해야 함
     // 외부 request 요청
     // todo 현재 고정 ip로 값 불러옴 -> 반복문 등을 통해 id 돌려야할 듯


### PR DESCRIPTION
#16 feat: 전체 및 상세조회 완료

as-is
1. 전체조회 -> mt20id별 오름차순 정렬 조회 가능
2. 상세조회 -> 프론트에서 mt20id 받아와 조회 가능

to-be
1. 상세조회에서 찜목록 추가에대한 버튼ㅇ르 클릭했을 때 유저 확인 위한 다른 컬럼 필요할 듯?