### PR TITLE
#27 feat: 찜목록 상세페이지 수정 및 예약된 공연 알람 기능

### DIFF
--- a/src/main/java/com/example/calenduck/domain/bookmark/Entity/Bookmark.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/Entity/Bookmark.java
@@ -15,8 +15,8 @@ import javax.persistence.*;
 @Getter
 @Setter
 @NoArgsConstructor
-@Where(clause = "deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE bookmark SET deleted_at = CONVERT_TZ(now(), 'UTC', 'Asia/Seoul') WHERE id = ?")
+//@Where(clause = "deleted_at IS NULL")
+//@SQLDelete(sql = "UPDATE bookmark SET deleted_at = CONVERT_TZ(now(), 'UTC', 'Asia/Seoul') WHERE id = ?")
 public class Bookmark extends Timestamped {
 
     @Id
@@ -46,4 +46,5 @@ public class Bookmark extends Timestamped {
         this.content = editBookmarkRequestDto.getContent();
         this.alarm = editBookmarkRequestDto.getAlarm();
     }
+
 }

--- a/src/main/java/com/example/calenduck/domain/bookmark/Repository/BookmarkRepository.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/Repository/BookmarkRepository.java
@@ -11,14 +11,14 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findAllByUser(User user);
     List<Bookmark> findAllByMt20id(String mt20id);
     Optional<Bookmark> findByUserAndMt20id(User user, String mt20id);
+    Optional<Bookmark> findByUser(User user);
+    Optional<Bookmark> findBymt20id(String mt20id);
+    Bookmark findByUserAndMt20idAndReservationDate(User user, String mt20id, String reservationDate);
 
     boolean existsByUserAndMt20id(User user, String mt20id);
     void deleteByUserAndMt20id(User user, String mt20id);
 
-//    @Modifying
-//    @Query("UPDATE Bookmark b SET b.modifiedAt = CURRENT_TIMESTAMP WHERE b.deletedAt IS NOT NULL")
-//    void updateModifiedAtWhenDeleted();
-    boolean existsByMt20id(String mt20id);
-    void deleteByMt20id(String mt20id);
+    List<String> findAllByUserAndAlarm(User user, String alarm);
+
 
 }

--- a/src/main/java/com/example/calenduck/domain/bookmark/dto/request/EditBookmarkRequestDto.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/dto/request/EditBookmarkRequestDto.java
@@ -2,8 +2,10 @@ package com.example.calenduck.domain.bookmark.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 public class EditBookmarkRequestDto {
 

--- a/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
@@ -1,0 +1,46 @@
+package com.example.calenduck.domain.detailInfo.entity;
+
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+public class DetailInfo {
+
+    @Id
+    private String mt20id;
+
+    @Column
+    private String mt10id;
+
+    @Column
+    private String prfnm;
+
+    @Column
+    private String fcltynm;
+
+    @Column
+    private String prfcast;
+
+    @Column
+    private String prfcrew;
+
+    @Column
+    private String prfruntime;
+
+    @Column
+    private String prfage;
+
+    @Column
+    private String entrpsnm;
+
+    @Column
+    private String pcseguidance;
+
+    @Column
+    private String genrenm;
+
+}

--- a/src/main/java/com/example/calenduck/domain/detailInfo/repository/DetailInfoRepository.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/repository/DetailInfoRepository.java
@@ -1,0 +1,11 @@
+package com.example.calenduck.domain.detailInfo.repository;
+
+import com.example.calenduck.domain.detailInfo.entity.DetailInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DetailInfoRepository extends JpaRepository<DetailInfo, Long> {
+
+    Optional<DetailInfo> findByMt20id(String mt20id);
+}

--- a/src/main/java/com/example/calenduck/domain/detailInfo/service/DetailInfoService.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/service/DetailInfoService.java
@@ -1,0 +1,25 @@
+package com.example.calenduck.domain.detailInfo.service;
+
+import com.example.calenduck.domain.bookmark.Entity.Bookmark;
+import com.example.calenduck.domain.bookmark.Service.BookmarkService;
+import com.example.calenduck.domain.detailInfo.entity.DetailInfo;
+import com.example.calenduck.domain.detailInfo.repository.DetailInfoRepository;
+import com.example.calenduck.global.exception.GlobalErrorCode;
+import com.example.calenduck.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DetailInfoService {
+
+    private final DetailInfoRepository detailInfoRepository;
+    private final BookmarkService bookmarkService;
+
+    public DetailInfo findDetailInfo(String mt20id) {
+        Bookmark bookmark = bookmarkService.findBookmarkToId(mt20id);
+        return detailInfoRepository.findByMt20id(bookmark.getMt20id())
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/example/calenduck/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/calenduck/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.ExecutionException;
 
 @RestController
 @Slf4j
@@ -41,8 +42,8 @@ public class UserController {
 
     @Operation(summary = "알람 전체 조회", description = "알람 전체 조회")
     @GetMapping("/alarm")
-    public ResponseEntity<?> getAlarms(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseMessage.SuccessResponse("로그인 성공", userService.getAlarms(userDetails.getUser()));
+    public ResponseEntity<?> getAlarms(@AuthenticationPrincipal UserDetailsImpl userDetails) throws ExecutionException, InterruptedException {
+        return ResponseMessage.SuccessResponse("알람 조회 성공", userService.getAlarms(userDetails.getUser()));
     }
 
 

--- a/src/main/java/com/example/calenduck/global/entity/Timestamped.java
+++ b/src/main/java/com/example/calenduck/global/entity/Timestamped.java
@@ -7,7 +7,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter

--- a/src/main/java/com/example/calenduck/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/example/calenduck/global/exception/GlobalErrorCode.java
@@ -29,7 +29,12 @@ public enum GlobalErrorCode {
     // 400 BAD_REQUEST - 잘못된 요청
     NOT_VALID_DATE(BAD_REQUEST, "유효한 날짜를 선택하세요."),
     // 404 Not Found - 찾을 수 없음
-    BOOKMARK_NOT_FOUND(NOT_FOUND, "찜목록이 존재하지 않습니다.");
+    BOOKMARK_NOT_FOUND(NOT_FOUND, "찜목록이 존재하지 않습니다."),
+    ALARM_NOT_FOUND(NOT_FOUND, "알람이 존재하지 않습니다."),
+
+    // DetailInfo
+    // 404 Not Found - 찾을 수 없음
+    NOT_FOUND_DETAILINFO(NOT_FOUND, "등록된 DETAILINFO가 없습니다");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
as-is
- 공연 수정할 때 알람 일정 저장 가능한데 1일전,3일전 등 문자로 저장이 아닌 20231010과 같은 날짜로 저장
- 찜목록에 예약날짜를 기준으로 -1, -3, -7일에 알람표시될 수 있게함

to-be
- 속도나 이런 부분에서 개선할 문제는 없을거라 판단 -> 메인페이지 검색부분 or 데이터 그래프 부분으로 마무리하면 될듯