### PR TITLE
#27 feat: 찜목록 상세페이지 수정 및 예약된 공연 알람 기능

### DIFF
--- a/src/main/java/com/example/calenduck/domain/bookmark/Entity/Bookmark.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/Entity/Bookmark.java
@@ -6,8 +6,7 @@ import com.example.calenduck.global.entity.Timestamped;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.Index;
 
 import javax.persistence.*;
 
@@ -24,6 +23,7 @@ public class Bookmark extends Timestamped {
     private Long id;
 
     @Column(nullable = false)
+    @Index(name = "idx_mt20id")
     private String mt20id;
 
     @Column

--- a/src/main/java/com/example/calenduck/domain/bookmark/Service/BookmarkService.java
+++ b/src/main/java/com/example/calenduck/domain/bookmark/Service/BookmarkService.java
@@ -16,7 +16,6 @@ import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.awt.print.Book;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -46,7 +45,9 @@ public class BookmarkService {
             throw new GlobalException(GlobalErrorCode.NOT_VALID_DATE);
         }
 
-        String reservationDate = String.valueOf(year) + String.valueOf(month) + String.valueOf(day);
+        String reservationDate = LocalDate.of(year, month, day)
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
         Bookmark bookmark = bookmarkRepository.findByUserAndMt20idAndReservationDate(user, mt20id, reservationDate);
         if (bookmark != null) {
             if (bookmark.getDeletedAt() == null) {
@@ -124,7 +125,8 @@ public class BookmarkService {
     @Transactional
     public void editBookmark(String mt20id, int year, int month, int day, User user, EditBookmarkRequestDto editBookmarkRequestDto) {
 
-        String reservationDate = String.valueOf(year) + String.valueOf(month) + String.valueOf(day);
+        String reservationDate = LocalDate.of(year, month, day)
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
         String[] alarm = editBookmarkRequestDto.getAlarm().split(",");
         LocalDate date = LocalDate.parse(reservationDate, DateTimeFormatter.BASIC_ISO_DATE);
@@ -191,10 +193,10 @@ public class BookmarkService {
             .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
     }
 
-    public Bookmark findBookmarkToId(String mt20id) {
-        return bookmarkRepository.findBymt20id(mt20id)
-            .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
+    public List<Bookmark> findBookmarksToId(String mt20id) {
+        return bookmarkRepository.findAllByMt20id(mt20id);
     }
+
 
     public List<Bookmark> findBookmarks(String mt20id) {
         return bookmarkRepository.findAllByMt20id(mt20id);

--- a/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/entity/DetailInfo.java
@@ -1,6 +1,7 @@
 package com.example.calenduck.domain.detailInfo.entity;
 
 import lombok.Getter;
+import org.hibernate.annotations.Index;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -11,6 +12,7 @@ import javax.persistence.Id;
 public class DetailInfo {
 
     @Id
+    @Index(name = "idx_mt20id")
     private String mt20id;
 
     @Column

--- a/src/main/java/com/example/calenduck/domain/detailInfo/service/DetailInfoService.java
+++ b/src/main/java/com/example/calenduck/domain/detailInfo/service/DetailInfoService.java
@@ -8,6 +8,7 @@ import com.example.calenduck.global.exception.GlobalErrorCode;
 import com.example.calenduck.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,9 +18,20 @@ public class DetailInfoService {
     private final BookmarkService bookmarkService;
 
     public DetailInfo findDetailInfo(String mt20id) {
-        Bookmark bookmark = bookmarkService.findBookmarkToId(mt20id);
+        List<Bookmark> bookmarks = bookmarkService.findBookmarksToId(mt20id);
+        if (bookmarks.isEmpty()) {
+            throw new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND);
+        }
+        Bookmark bookmark = bookmarks.get(0); // Assuming you want to retrieve the first bookmark
+
         return detailInfoRepository.findByMt20id(bookmark.getMt20id())
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
     }
+
+//    public DetailInfo findDetailInfo(String mt20id) {
+//        Bookmark bookmark = bookmarkService.findBookmarkToId(mt20id);
+//        return detailInfoRepository.findByMt20id(bookmark.getMt20id())
+//                .orElseThrow(() -> new GlobalException(GlobalErrorCode.BOOKMARK_NOT_FOUND));
+//    }
 
 }


### PR DESCRIPTION
as-is
- 공연 수정할 때 알람 일정 저장 가능한데 1일전,3일전 등 문자로 저장이 아닌 20231010과 같은 날짜로 저장
- 찜목록에 예약날짜를 기준으로 -1, -3, -7일에 알람표시될 수 있게함

to-be
- 속도나 이런 부분에서 개선할 문제는 없을거라 판단 -> 메인페이지 검색부분 or 데이터 그래프 부분으로 마무리하면 될듯